### PR TITLE
test ssl formats ciphers without errors in `riak admin security ciphers`

### DIFF
--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -33,6 +33,8 @@ confirm() ->
     [Node] = rt:deploy_nodes(1),
     ?assertEqual(ok, rt:wait_until_nodes_ready([Node])),
 
+    security_ciphers_test(Node),
+
     %% Verify node-up behavior
     ping_up_test(Node),
     attach_direct_up_test(Node),
@@ -164,6 +166,13 @@ getpid_down_test(Node) ->
         PidOut =:= ""
         orelse rt:str(PidOut, " not responding to ping")
         orelse rt:str(PidOut, " not running") ).
+
+security_ciphers_test(Node) ->
+    ?LOG_INFO("Test cipher strings", []),
+    {ok, {ExitCode, Output}} = rt:admin(Node, ["security", "ciphers"], [return_exit_code]),
+    ?assertEqual(0, ExitCode),
+    ?assertEqual(nomatch, re:run(Output, "RPC to '.+' failed: {'EXIT',")).
+
 
 not_running(Output) ->
     %% Depending on relx version, a variety of output may be printed.

--- a/tests/basic_command_line.erl
+++ b/tests/basic_command_line.erl
@@ -171,7 +171,9 @@ security_ciphers_test(Node) ->
     ?LOG_INFO("Test cipher strings", []),
     {ok, {ExitCode, Output}} = rt:admin(Node, ["security", "ciphers"], [return_exit_code]),
     ?assertEqual(0, ExitCode),
-    ?assertEqual(nomatch, re:run(Output, "RPC to '.+' failed: {'EXIT',")).
+    ?assertEqual(match, element(1, re:run(Output, "Configured ciphers"))),
+    ?assertEqual(match, element(1, re:run(Output, "Valid ciphers\\([0-9]+\\)"))),
+    ?assertEqual(match, element(1, re:run(Output, "AES256"))).
 
 
 not_running(Output) ->


### PR DESCRIPTION
Producing cipher strings for printing with `riak admin security ciphers` uses undocumented functions (such as `ssl_cipher_format:suite_map_to_openssl_str/1`, still existing in otp-26, or `ssl_cipher_format:suite_bin_to_map/1`, already gone).

This test case is to trip whenever such breakage occurs in future.

Depends on https://github.com/OpenRiak/riak_core/pull/34.