### PR TITLE
Wait until caps renegotiation completes on node upgrade

### DIFF
--- a/groups/core_all
+++ b/groups/core_all
@@ -13,6 +13,7 @@ location_upgrade
 node_repair_big
 node_repair_nval
 verify_build_cluster
+verify_build_cluster_caps_race
 verify_claimant
 verify_dynamic_ring
 verify_leave

--- a/src/rt.erl
+++ b/src/rt.erl
@@ -2706,13 +2706,15 @@ make_multi_backend_config(Other) ->
 get_backends() ->
     Backends = ?HARNESS:get_backends(),
     case Backends of
-        [riak_kv_bitcask_backend] -> bitcask;
-        [riak_kv_eleveldb_backend] -> eleveldb;
-        [riak_kv_memory_backend] -> memory;
-        [riak_kv_leveled_backend] -> leveled;
-        [Other] -> Other;
-        MoreThanOne -> MoreThanOne
+        [Single] -> known_backend(Single);
+        MoreThanOne -> [known_backend(A) || A <- MoreThanOne]
     end.
+
+known_backend(riak_kv_bitcask_backend) -> bitcask;
+known_backend(riak_kv_eleveldb_backend) -> eleveldb;
+known_backend(riak_kv_memory_backend) -> memory;
+known_backend(riak_kv_leveled_backend) -> leveled;
+known_backend(X) -> X.
 
 -spec get_backend(rtt:app_config()) -> rtt:backend() | error.
 get_backend(AppConfigProplist) ->

--- a/tests/verify_basic_upgrade.erl
+++ b/tests/verify_basic_upgrade.erl
@@ -111,8 +111,8 @@
 
 confirm() ->
 
+    KVBackend = get_backend(),
     TestMetaData = riak_test_runner:metadata(),
-    KVBackend = proplists:get_value(backend, TestMetaData),
     OldVsn = proplists:get_value(upgrade_version, TestMetaData, previous),
 
     ?LOG_INFO("*****************************"),
@@ -181,8 +181,7 @@ upgrade(Node, NewVsn) ->
     ok.
 
 backend_size(Node) ->
-    TestMetaData = riak_test_runner:metadata(),
-    KVBackend = proplists:get_value(backend, TestMetaData),
+    KVBackend = get_backend(),
     {ok, DataDir} =
         rpc:call(Node, application, get_env, [riak_core, platform_data_dir]),
     BackendDir = filename:join(DataDir, base_dir_for_backend(KVBackend)),
@@ -191,6 +190,13 @@ backend_size(Node) ->
     {match, [SzOnly]} =
         re:run(SzTxt, "(?<SzOnly>[0-9]+)M.*", [{capture, all_names, list}]),
     list_to_integer(SzOnly).
+
+get_backend() ->
+    case rt:get_backends() of
+        [B1|_] ->
+            B1;
+        B -> B
+    end.
 
 base_dir_for_backend(leveled) ->
     "leveled";

--- a/tests/verify_dt_upgrade.erl
+++ b/tests/verify_dt_upgrade.erl
@@ -69,7 +69,9 @@ populate_counters(Node) ->
 verify_counters(Node) ->
     ?LOG_INFO("Verifying counters on ~0p", [Node]),
     RHC = rt:httpc(Node),
-    ?assertMatch({ok, 4}, rhc:counter_val(RHC, ?COUNTER_BUCKET, <<"pbkey">>)),
+    PBKey = <<"pbkey">>,
+    rt:wait_until(not_503(RHC, PBKey)),
+    ?assertMatch({ok, 4}, rhc:counter_val(RHC, ?COUNTER_BUCKET, PBKey)),
 
     PBC = rt:pbc(Node),
     ?assertEqual({ok, 2}, riakc_pb_socket:counter_val(PBC, ?COUNTER_BUCKET, <<"httpkey">>)),
@@ -82,6 +84,19 @@ verify_counters(Node) ->
             ok
     end,
     ok.
+
+not_503(Client, Key) ->
+    fun() ->
+            Res = rhc:counter_val(Client, ?COUNTER_BUCKET, Key),
+            case Res of
+                %% expect 503 for a brief while
+                {error, {ok, "503", _Headers, <<"Counters are not supported.">>}} ->
+                    ?LOG_INFO("\"Counters are not supported\" pending caps negotiation post upgrade", []),
+                    false;
+                _ ->
+                    true
+            end
+    end.
 
 upgrade(Node, NewVsn) ->
     ?LOG_INFO("Upgrading ~0p to ~0p", [Node, NewVsn]),


### PR DESCRIPTION
When a node with reduced capabilities joins the cluster, we should take care accordingly to reduce the set of supported capabilities in the cluster as well. This was done, in 2016, in a commit that was [reverted](https://github.com/basho/riak_core/pull/871/changes/699f83da6af1c2d9e8d0d203447eb59227ab77c4) soon thereafter, because it introduced "[race conditions](https://github.com/basho/riak_core/pull/871#issue-184287823) when nodes restart and gossip capabilities".

These "racing conditions", _apparently_, refer to a temporary state when nodes report inadequate capabilities, as when, for example, triggered [here](https://github.com/TI-Tokyo/riak_test/blob/openriak-3.4/tests/verify_dt_upgrade.erl#L72).

A mirror condition exists when the last node with reduced capabilities relative to the rest of the cluster, is upgraded. The result, after capability gossip and renegotiation, is the full set of capabilities restored cluster-wide.

This PR adds a wait, in the only test that regressed following un-reversion of the "filter caps on downgrade" commit (verify_dt_upgrade), until, when an upgraded node is starting, the capabilities are renegotiated.

Related PR in riak_core is https://github.com/OpenRiak/riak_core/pull/63.

(Also included in this PR is an unrelated change that uses direct `rt:get_backends/0` instead of trying to extract backend info from riak_test metadata, where such info is no longer found.)